### PR TITLE
FIX: changelog for v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v0.2.0 (2025-09-11)
+
+- Add SqlUnitOfWork, (closes #9)
+
+
 ## v0.1.1 (2025-09-01)
 
 - Fix package classifiers, #1


### PR DESCRIPTION
In this PR we add a missing info about v0.2.0 release in CHANGELOG.md.

Closes #22